### PR TITLE
Add OpenSpec dogfooding showcase, contributor templates, and demo CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report broken demo behavior or regressions
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+Describe the observed behavior.
+
+## Expected behavior
+
+Describe the expected behavior.
+
+## Reproduction
+
+```bash
+# exact commands
+```
+
+## Environment
+
+- OS:
+- Python:
+- Branch/commit:
+
+## Logs / Screenshots
+
+Paste relevant output from `make demo`, `make test`, or CI logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussion
+    url: https://github.com/nold-ai/specfact-demo-repo/discussions
+    about: Ask broader questions and share ideas.

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,25 @@
+---
+name: Good first issue
+about: Propose a small contributor-friendly improvement
+title: "[Good First Issue] "
+labels: "good first issue,demo-scenario"
+assignees: ""
+---
+
+## Problem
+
+What is confusing, missing, or hard for first-time users?
+
+## Proposed small change
+
+Describe a scoped task that can be completed in one PR.
+
+## Acceptance criteria
+
+- [ ] Clear command or file-level outcome is defined
+- [ ] `make demo` behavior remains reproducible
+- [ ] Docs are updated if user-facing behavior changes
+
+## Suggested files
+
+List likely files (example: `README.md`, `Makefile`, `fixtures/`, `tests/`).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+Describe what changed and why.
+
+## Validation
+
+- [ ] `make demo`
+- [ ] `make test`
+- [ ] If OpenSpec changed: `openspec validate <change-id> --strict`
+
+## Contributor Checklist
+
+- [ ] Change is scoped and avoids unrelated refactors
+- [ ] Docs updated for user-facing command/output changes
+- [ ] New behavior has tests or clear rationale for no tests

--- a/.github/workflows/demo-ci.yml
+++ b/.github/workflows/demo-ci.yml
@@ -1,0 +1,41 @@
+name: demo-ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "feature/**"
+
+jobs:
+  verify-demo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Prepare artifact directory
+        run: mkdir -p artifacts
+
+      - name: Run demo flow
+        run: make demo | tee artifacts/demo-ci.log
+
+      - name: Run tests
+        run: make test | tee artifacts/test-ci.log
+
+      - name: Upload demo artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-artifacts
+          path: |
+            artifacts/latest/**
+            artifacts/pass/**
+            artifacts/demo-ci.log
+            artifacts/test-ci.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to SpecFact Demo Repo
+
+Thanks for contributing. This repo is intentionally small and reproducible, so changes should
+keep demo flows deterministic and fast.
+
+## Quick Start
+
+```bash
+make demo
+make test
+```
+
+## Ways You Can Contribute
+
+- Improve demo scenarios:
+  add new fixture variants that show realistic policy failures or recoveries.
+- Improve developer UX:
+  simplify output readability and command ergonomics in `Makefile` and `README.md`.
+- Expand plugin examples:
+  add safe lifecycle plugins under `plugins/official/`.
+- Improve OpenSpec dogfooding:
+  refine issue-sync flow and source-tracking validation in `scripts/`.
+- Improve CI reliability:
+  make demo verification faster and clearer in GitHub Actions.
+
+## Good First Issue Labels
+
+Use these labels when opening or triaging issues:
+
+- `good first issue`: Small, bounded, newcomer-friendly tasks.
+- `help wanted`: Valuable tasks that need contributor help.
+- `demo-scenario`: New or improved showcase scenario work.
+- `docs`: Documentation clarity and onboarding improvements.
+
+## Contribution Expectations
+
+- Keep changes scoped and avoid unrelated refactors.
+- Preserve or improve reproducibility of `make demo`.
+- Add/update tests when behavior changes.
+- Update README when user-facing commands or outputs change.
+
+## Pull Request Checklist
+
+- Run:
+  `make demo`
+- Run:
+  `make test`
+- If OpenSpec artifacts changed, run:
+  `openspec validate <change-id> --strict`
+- Summarize behavior changes and validation output in PR description.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository is a reproducible "aha moment" for SpecFact:
 
 You can run the full flow in less than 5 minutes.
 
+See `CONTRIBUTING.md` for contributor workflows and issue labels.
+
 ## Quickstart (3 commands)
 
 ```bash
@@ -122,6 +124,31 @@ Source tracking is written to:
 
 - `openspec/changes/demo-github-issue-sync-showcase/source_tracking.json`
 - `openspec/changes/demo-github-issue-sync-showcase/proposal.md` (`## Source Tracking`)
+
+## Visual demo
+
+Add a short terminal GIF at:
+
+- `docs/assets/demo-output.gif`
+
+Generation instructions:
+
+- `docs/assets/README.md`
+
+## Ways you can contribute
+
+- Improve demo scenarios (additional realistic BLOCK and PASS cases)
+- Improve output readability (`make explain`, `make diff-report`)
+- Add plugin showcase scenarios under `plugins/official/`
+- Improve OpenSpec issue-sync validation and source tracking
+- Improve CI reliability and speed for demo verification
+
+Recommended issue labels:
+
+- `good first issue`
+- `help wanted`
+- `demo-scenario`
+- `docs`
 
 ## Repo layout
 

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,19 @@
+# Demo Visual Assets
+
+Place the README animation at:
+
+- `docs/assets/demo-output.gif`
+
+## Capture instructions
+
+1. Run the demo and save a log:
+   `make demo | tee artifacts/demo-capture.log`
+2. Record terminal session with your preferred tool (examples):
+   - `asciinema rec artifacts/demo.cast`
+   - `vhs demo.tape` (if VHS is installed)
+3. Export to GIF and write to:
+   `docs/assets/demo-output.gif`
+4. Keep animation short (20-45 seconds) and include:
+   - BLOCK result
+   - explain output
+   - PASS result


### PR DESCRIPTION
## Summary

This PR keeps the OpenSpec + GitHub dogfooding showcase, excludes `.cursor` from version control, and adds contributor-magnet improvements based on review feedback.

## Recommendations Adopted

- [x] Minimal reproducible demo loop with immediate feedback
  - `make demo` (`BLOCK -> explain -> PASS`) and `make diff-report`
- [x] Concrete contribution pathways
  - `CONTRIBUTING.md`
  - README section: "Ways you can contribute"
- [x] Good-first-issue and bug report templates
  - `.github/ISSUE_TEMPLATE/good_first_issue.md`
  - `.github/ISSUE_TEMPLATE/bug_report.md`
- [x] PR template for consistent quality gates
  - `.github/pull_request_template.md`
- [x] CI auto-verification + artifact upload
  - `.github/workflows/demo-ci.yml` (runs `make demo` and `make test`)
- [x] Visual demo guidance (GIF path + capture steps)
  - `docs/assets/README.md`

## OpenSpec Dogfooding Evidence

- OpenSpec change: `openspec/changes/demo-github-issue-sync-showcase/`
- Synced issue: https://github.com/nold-ai/specfact-demo-repo/issues/2
- Source tracking:
  - `openspec/changes/demo-github-issue-sync-showcase/source_tracking.json`

## Repo Hygiene

- `.cursor/` is now ignored in `.gitignore`
- Previously tracked `.cursor` scaffold files removed from git tracking

## Validation

- [x] `make demo`
- [x] `make test`
- [x] `openspec validate demo-github-issue-sync-showcase --strict`
- [x] `make validate-sync CHANGE=demo-github-issue-sync-showcase GITHUB_REPO=nold-ai/specfact-demo-repo`
