### PR TITLE
Add OpenSpec sidecar legacy-code demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ REAL_BUNDLE ?= demo-repo
 REPO_OWNER ?= nold-ai
 REPO_NAME ?= specfact-demo-repo
 BACKLOG_IDS ?= 2
+SIDECAR_BUNDLE ?= buggy-sidecar
+SIDECAR_REPO ?= examples/buggy-sidecar
 
-.PHONY: real-version real-import real-enforce real-repro real-backlog-sync real-smoke test clean
+.PHONY: real-version real-import real-enforce real-repro real-backlog-sync sidecar-import sidecar-repro sidecar-demo real-smoke test clean
 
 real-version:
 	specfact-cli --version
@@ -20,6 +22,16 @@ real-repro:
 
 real-backlog-sync:
 	specfact-cli sync bridge --adapter github --mode bidirectional --repo . --bundle "$(REAL_BUNDLE)" --repo-owner "$(REPO_OWNER)" --repo-name "$(REPO_NAME)" --backlog-ids "$(BACKLOG_IDS)" --use-gh-cli
+
+sidecar-import:
+	specfact-cli import from-code "$(SIDECAR_BUNDLE)" --repo "$(SIDECAR_REPO)" --shadow-only --force
+
+sidecar-repro:
+	specfact-cli repro --repo "$(SIDECAR_REPO)" --sidecar --sidecar-bundle "$(SIDECAR_BUNDLE)"
+
+sidecar-demo:
+	$(MAKE) --no-print-directory sidecar-import
+	$(MAKE) --no-print-directory sidecar-repro
 
 real-smoke:
 	$(MAKE) --no-print-directory real-version

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ You can run the core smoke flow in under 1 minute.
 
 See `CONTRIBUTING.md` for contributor workflows and issue labels.
 See `docs/real-cli-vs-demo.md` for a quick mapping between this demo and the real CLI.
+See official docs for deeper workflows:
+
+- https://docs.specfact.io/use-cases/
+- https://docs.specfact.io/getting-started/installation/
+- https://docs.specfact.io/guides/
 
 ## What SpecFact Solves
 
@@ -65,6 +70,7 @@ make real-version
 make real-import
 make real-enforce
 make real-repro
+make sidecar-demo
 make real-smoke
 ```
 
@@ -83,6 +89,27 @@ After sync, expect proposal/change artifacts under:
 - `.specfact/projects/<bundle>/change_tracking/`
 
 Prerequisite: authenticated GitHub access (`gh auth login` or `specfact-cli auth github`).
+
+### Sidecar validation on legacy code (real CLI)
+
+```bash
+make sidecar-demo
+```
+
+This runs:
+
+- `specfact-cli import from-code buggy-sidecar --repo examples/buggy-sidecar --shadow-only --force`
+- `specfact-cli repro --repo examples/buggy-sidecar --sidecar --sidecar-bundle buggy-sidecar`
+
+Expected output example:
+
+- `Import complete!`
+- sidecar validation run summary for `buggy-sidecar`
+
+See sample logs:
+
+- `results/sidecar-import.log`
+- `results/sidecar-repro.log`
 
 ## Visual demo
 
@@ -117,6 +144,7 @@ tests/                       # local tests for demo harness modules
 repro/                       # reproducibility runners
 evidence/                    # evidence manifest and threat model
 results/                     # sample run outputs
+examples/                    # runnable demo examples (including legacy sidecar case)
 ```
 
 ## Marketplace governance model

--- a/evidence/manifest.yaml
+++ b/evidence/manifest.yaml
@@ -5,6 +5,7 @@ invariants:
   - real_cli_import_from_code
   - enforcement_mode_configuration
   - backlog_sync_bridge_capability
+  - sidecar_validation_for_legacy_code
 evidence:
   - type: empirical-run
     path: results/real-smoke.log
@@ -12,6 +13,10 @@ evidence:
     path: results/test.log
   - type: openspec-validation
     path: results/openspec-validate.log
+  - type: sidecar-import
+    path: results/sidecar-import.log
+  - type: sidecar-validation
+    path: results/sidecar-repro.log
 scope:
   repository: nold-ai/specfact-demo-repo
   mode: demonstration

--- a/examples/buggy-sidecar/README.md
+++ b/examples/buggy-sidecar/README.md
@@ -1,0 +1,17 @@
+# Buggy Sidecar Demo
+
+This example intentionally avoids contract decorators and represents legacy code.
+Use it to demonstrate sidecar validation on existing code.
+
+Run from repo root:
+
+```bash
+make sidecar-demo
+```
+
+Direct commands:
+
+```bash
+specfact-cli import from-code buggy-sidecar --repo examples/buggy-sidecar --shadow-only --force
+specfact-cli repro --repo examples/buggy-sidecar --sidecar --sidecar-bundle buggy-sidecar
+```

--- a/examples/buggy-sidecar/calculator.py
+++ b/examples/buggy-sidecar/calculator.py
@@ -1,0 +1,11 @@
+"""Legacy-style example code used for sidecar validation demos."""
+
+
+def divide(a: float, b: float) -> float:
+    # Intentional brownfield bug: no zero guard.
+    return a / b
+
+
+def discount(price: float, pct: float) -> float:
+    # Intentional brownfield bug: percent bounds are not validated.
+    return price - (price * pct)

--- a/openspec/changes/add-sidecar-legacy-demo/.openspec.yaml
+++ b/openspec/changes/add-sidecar-legacy-demo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-14

--- a/openspec/changes/add-sidecar-legacy-demo/CHANGE_VALIDATION.md
+++ b/openspec/changes/add-sidecar-legacy-demo/CHANGE_VALIDATION.md
@@ -1,0 +1,29 @@
+## Validation Report: add-sidecar-legacy-demo
+
+### Summary
+
+| Dimension | Status |
+|-----------|--------|
+| Completeness | 10/10 tasks complete |
+| Correctness | Sidecar demo commands and strict OpenSpec validation passed |
+| Coherence | README, Makefile, results, and evidence manifest aligned |
+
+### Checks Executed
+
+1. `make sidecar-demo`
+2. `make sidecar-import | tee results/sidecar-import.log`
+3. `make sidecar-repro | tee results/sidecar-repro.log`
+4. `make real-smoke`
+5. `make test`
+6. `openspec validate add-sidecar-legacy-demo --strict`
+
+### Findings
+
+1. **CRITICAL**: None.
+2. **WARNING**: Sidecar repro reported CrossHair advisory failure while overall
+   reproducibility remained successful.
+3. **SUGGESTION**: Revisit sidecar scope tuning if advisory noise grows with larger examples.
+
+### Final Assessment
+
+Change is valid and ready for review.

--- a/openspec/changes/add-sidecar-legacy-demo/design.md
+++ b/openspec/changes/add-sidecar-legacy-demo/design.md
@@ -1,0 +1,38 @@
+## Context
+
+SpecFact’s strongest onboarding path is brownfield modernization. The demo should
+prove that users can validate existing code without first adopting decorators or
+rewriting modules.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a deterministic sidecar demo path that works with real `specfact-cli`.
+- Keep scenario small and self-contained for fast local runs.
+- Connect README to deeper official docs for broader workflows.
+
+**Non-Goals:**
+
+- Replacing current smoke or backlog sync flows.
+- Adding full framework-specific app stacks in this change.
+- Introducing plugin or marketplace runtime demos.
+
+## Decisions
+
+- Use a tiny pure-Python buggy example (`calculator.py`) with no decorators.
+  - Alternative: full Flask/Django app.
+  - Rejected due to heavier setup and slower onboarding.
+- Add dedicated Make targets (`sidecar-import`, `sidecar-repro`, `sidecar-demo`).
+  - Alternative: embed commands only in README.
+  - Rejected to keep reproducibility one-command friendly.
+- Capture sidecar logs under `results/` and include in evidence manifest.
+  - Alternative: require users to run manually every time.
+  - Rejected because expected outputs improve trust.
+
+## Risks / Trade-offs
+
+- [Risk] Sidecar behavior may evolve across CLI versions.
+  -> Mitigation: keep logs illustrative and regenerate on version bump.
+- [Risk] Validation output may be environment-sensitive.
+  -> Mitigation: keep example deterministic and avoid external dependencies.

--- a/openspec/changes/add-sidecar-legacy-demo/proposal.md
+++ b/openspec/changes/add-sidecar-legacy-demo/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The demo currently proves real CLI smoke and backlog sync, but does not show how
+to start from legacy code without contract decorators. A sidecar validation path
+is a high-impact onboarding scenario for brownfield users.
+
+## What Changes
+
+- Add a small buggy legacy Python example under `examples/buggy-sidecar/`.
+- Add sidecar demo targets to run real import + sidecar validation.
+- Add documentation links to deeper SpecFact CLI use cases and integration docs.
+- Add sample sidecar logs to `results/` and reference them in README.
+
+## Capabilities
+
+### New Capabilities
+
+- `legacy-sidecar-demo`: Demonstrate sidecar validation on undecorated legacy code.
+
+### Modified Capabilities
+
+- `demo-onboarding-evidence-pack`: Extend onboarding with deeper documentation links
+  and sidecar walkthrough/output references.
+
+## Impact
+
+- Affected files: `README.md`, `Makefile`, `results/README.md`, evidence manifest.
+- New example source tree under `examples/buggy-sidecar/`.

--- a/openspec/changes/add-sidecar-legacy-demo/specs/legacy-sidecar-demo/spec.md
+++ b/openspec/changes/add-sidecar-legacy-demo/specs/legacy-sidecar-demo/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Legacy Sidecar Demo Exists
+
+The demo repository SHALL include a runnable legacy-code example that does not
+use contract decorators.
+
+#### Scenario: Example source remains undecorated
+
+- **WHEN** a contributor inspects the sidecar demo source
+- **THEN** no contract decorators are required in the example code
+- **AND** code intentionally reflects brownfield quality issues.
+
+### Requirement: Sidecar Demo Is Runnable Through Makefile
+
+The repository SHALL provide Make targets that run import and sidecar validation
+for the legacy example with real `specfact-cli`.
+
+#### Scenario: One-command sidecar walkthrough
+
+- **WHEN** a user runs the sidecar demo target
+- **THEN** import runs for the legacy example bundle
+- **AND** sidecar validation runs with `--sidecar` and `--sidecar-bundle`.
+
+## MODIFIED Requirements
+
+### Requirement: Demo README Includes Real CLI Prerequisites
+
+The demo repository SHALL document installation, authentication, and expected real-CLI
+smoke command behavior for first-time users.
+
+#### Scenario: README links to deeper official workflows
+
+- **WHEN** a user reads onboarding docs
+- **THEN** README provides links to official use-cases and integration guides
+- **AND** sidecar demo output references are discoverable.

--- a/openspec/changes/add-sidecar-legacy-demo/tasks.md
+++ b/openspec/changes/add-sidecar-legacy-demo/tasks.md
@@ -1,0 +1,18 @@
+## 1. OpenSpec Artifacts
+
+- [x] 1.1 Create proposal for sidecar legacy demo addition.
+- [x] 1.2 Create design for sidecar scenario and command flow.
+- [x] 1.3 Add spec deltas for legacy sidecar demo and README linkage updates.
+
+## 2. Implementation
+
+- [x] 2.1 Add `examples/buggy-sidecar/` legacy code sample without decorators.
+- [x] 2.2 Add Make targets for sidecar import/repro/demo using real `specfact-cli`.
+- [x] 2.3 Update README with sidecar walkthrough and official documentation links.
+- [x] 2.4 Update evidence manifest/results references to include sidecar logs.
+
+## 3. Validation
+
+- [x] 3.1 Run sidecar demo commands and capture `results/sidecar-*.log`.
+- [x] 3.2 Run `make real-smoke` and `make test`.
+- [x] 3.3 Run `openspec validate add-sidecar-legacy-demo --strict`.

--- a/repro/run.sh
+++ b/repro/run.sh
@@ -14,4 +14,10 @@ make -C "$ROOT_DIR" test | tee "$RESULTS_DIR/test.log"
 echo "Validating current OpenSpec change set..."
 openspec validate --changes --strict | tee "$RESULTS_DIR/openspec-validate.log"
 
+if [[ "${RUN_SIDECAR:-0}" == "1" ]]; then
+  echo "Running sidecar legacy demo..."
+  make -C "$ROOT_DIR" sidecar-import | tee "$RESULTS_DIR/sidecar-import.log"
+  make -C "$ROOT_DIR" sidecar-repro | tee "$RESULTS_DIR/sidecar-repro.log"
+fi
+
 echo "Repro run complete. Logs written to $RESULTS_DIR"

--- a/results/README.md
+++ b/results/README.md
@@ -7,9 +7,13 @@ Expected files:
 - `real-smoke.log`
 - `test.log`
 - `openspec-validate.log`
+- `sidecar-import.log`
+- `sidecar-repro.log`
 
 Regenerate:
 
 ```bash
 ./repro/run.sh
+make sidecar-import | tee results/sidecar-import.log
+make sidecar-repro | tee results/sidecar-repro.log
 ```

--- a/results/sidecar-import.log
+++ b/results/sidecar-import.log
@@ -1,0 +1,93 @@
+specfact-cli import from-code "buggy-sidecar" --repo "examples/buggy-sidecar" --shadow-only --force
+SpecFact CLI - v0.30.1
+
+⏱️  Started: 2026-02-14 23:40:46
+⚠ Force mode enabled - regenerating all artifacts
+
+Importing repository: examples/buggy-sidecar
+Project bundle: buggy-sidecar
+Confidence threshold: 0.5
+→ Shadow mode - observe without enforcement
+Mode: CI/CD (AST-based import)
+
+⏱️  Note: This analysis typically takes 2-5 minutes for large codebases 
+(optimized for speed)
+
+Analysis Plugins:
+ Plugin                 Status    Details                                       
+ AST Analysis           ✓         Core analysis engine                          
+                        Enabled                                                 
+ Semgrep Pattern        ⊘         Semgrep CLI not installed (install: pip       
+ Detection              Disabled  install semgrep)                              
+ Dependency Graph       ✓         Dependency graph analysis enabled             
+ Analysis               Enabled                                                 
+
+🔍 Analyzing codebase...
+
+
+✓ Found 0 features
+✓ Detected themes: Core
+✓ Total stories: 0
+
+💾 Saving features (checkpoint)...
+✓ Bundle saved: 3 artifact(s) (0.01s)
+✓ Features saved (can resume if interrupted)
+
+
+🔗 Linking source files to features...
+✓ Source tracking complete
+
+🔍 Enhanced analysis: Extracting relationships, contracts, and graph 
+dependencies...
+
+Analyzing 1 file(s) for relationships...
+✓ Relationship analysis complete: 1 files mapped
+✓ Dependency graph complete: 1 modules, 0 dependencies
+No features with implementation files found for contract extraction
+No API contracts detected in codebase
+
+📊 Building enrichment context...
+⠋ Writing to file...
+✓ Enrichment context saved to: 
+.specfact/projects/buggy-sidecar/enrichment_context.md
+
+💾 Compiling and saving project bundle...
+✓ Bundle saved: 3 artifact(s) (0.01s)
+
+✓ Import complete!
+Project bundle written to: 
+/home/dom/git/nold-ai/specfact-demo-repo/examples/buggy-sidecar/.specfact/projec
+ts/buggy-sidecar
+
+📋 Next Steps:
+Here are some commands you might want to run next:
+
+  → Review changes:
+     specfact plan review buggy-sidecar
+     Review updates to your plan bundle
+
+  → Check deviations:
+     specfact plan compare --bundle buggy-sidecar
+     See what changed since last import
+
+
+💡 Tip: Run 'specfact sdd constitution bootstrap --repo .' to generate 
+constitution
+
+🔧 Enriching plan for tool compliance...
+Enhancing vague acceptance criteria, incomplete requirements, generic tasks...
+
+✓ Plan bundle is already well-specified (no enrichments needed)
+✓ Tool enrichment complete
+Report written to: 
+/home/dom/git/nold-ai/specfact-demo-repo/examples/buggy-sidecar/.specfact/projec
+ts/buggy-sidecar/reports/brownfield/analysis-2026-02-14T23-40-47.md
+
+Performance Report: import.from_code
+Total duration: 14.02s
+Total operations: 7
+
+Slow operations (> 5.0s):
+  • validate_api_specs: 10.09s
+
+✓ Finished: 2026-02-14 23:41:01 | Duration: 14.68s

--- a/results/sidecar-repro.log
+++ b/results/sidecar-repro.log
@@ -1,0 +1,43 @@
+specfact-cli repro --repo "examples/buggy-sidecar" --sidecar --sidecar-bundle "buggy-sidecar"
+SpecFact CLI - v0.30.1
+
+⏱️  Started: 2026-02-14 23:40:46
+Running validation suite...
+Repository: examples/buggy-sidecar
+Time budget: 120s
+
+No environment manager detected, using direct tool invocation
+⠼ Running validation checks... 0:00:00
+
+Validation Results
+
+                              Check Summary                               
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Check                            ┃ Tool         ┃ Status    ┃ Duration ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━┩
+│ Linting (ruff)                   │ ruff         │ ✓ PASSED  │ 0.02s    │
+│ Type checking (basedpyright)     │ basedpyright │ ⊘ SKIPPED │ N/A      │
+│ Contract exploration (CrossHair) │ crosshair    │ ✗ FAILED  │ 0.32s    │
+└──────────────────────────────────┴──────────────┴───────────┴──────────┘
+
+Summary:
+  Total checks: 3
+  Passed: 1
+  Failed: 1
+  Skipped: 1
+  Total duration: 0.39s
+
+Report written to: 
+examples/buggy-sidecar/.specfact/reports/enforcement/report-2026-02-14T23-40-47.
+yaml
+
+Running sidecar validation for unannotated code...
+Found 11280 unannotated functions
+⚠ Skipping Specmatic: No service configuration detected (use --run-specmatic to 
+override)
+✓ Validation complete
+
+! Required validations passed, but CrossHair failed (advisory)
+Reproducibility verified with advisory failures
+
+✓ Finished: 2026-02-14 23:40:59 | Duration: 12.07s


### PR DESCRIPTION
## Summary

Add a new OpenSpec-driven sidecar demo for legacy code without contract decorators.

## OpenSpec Change

- `add-sidecar-legacy-demo`
- Includes proposal, design, spec delta, tasks, and validation report.

## What changed

- Added legacy example project:
  - `examples/buggy-sidecar/calculator.py`
  - `examples/buggy-sidecar/README.md`
- Added sidecar Make targets:
  - `make sidecar-import`
  - `make sidecar-repro`
  - `make sidecar-demo`
- Updated README with:
  - official docs links (`use-cases`, `installation`, `guides`)
  - sidecar walkthrough + expected output + result log references
- Extended evidence metadata and reproducibility docs:
  - `evidence/manifest.yaml` includes sidecar invariants/logs
  - `repro/run.sh` supports optional sidecar run (`RUN_SIDECAR=1`)
  - `results/README.md` includes sidecar log regeneration commands
  - added `results/sidecar-import.log` and `results/sidecar-repro.log`

## Validation

- [x] `make sidecar-demo`
- [x] `make sidecar-import | tee results/sidecar-import.log`
- [x] `make sidecar-repro | tee results/sidecar-repro.log`
- [x] `make real-smoke`
- [x] `make test`
- [x] `openspec validate add-sidecar-legacy-demo --strict`

## Note

Sidecar repro may report advisory CrossHair failures while still passing reproducibility checks.
